### PR TITLE
Get ready for Manifest v2 deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ A firefox extension that removes the obtrusive popup that prevents you from view
 
 When a popup appears simply click the extension icon to remove the popup and continue reading the article.
 
-Install the .crx file from the assets to run. I have requested for this to be put up on AMO, nothing received yet.
-
+I have requested AMO for a .xpi file. Hang on. 
 This is sure to work on most websites from my experience.
+

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A firefox extension that removes the obtrusive popup that prevents you from view
 When a popup appears simply click the extension icon to remove the popup and continue reading the article.
 
 
-To download this extension, go to the latest release and download the .xpi file. It is signed by Mozilla.
+To download this extension, go to the latest release and download the .xpi file. It is signed by Mozilla, or click [here](https://addons.mozilla.org/en-US/firefox/addon/adblock-detector-bypass/)
 
 This is sure to work on most websites from my experience.
 

--- a/README.md
+++ b/README.md
@@ -7,3 +7,5 @@ When a popup appears simply click the extension icon to remove the popup and con
 I have requested AMO for a .xpi file. Hang on. 
 This is sure to work on most websites from my experience.
 
+
+I made this because the original extension was very cool and I like to use it. As soon as I heard that Chrome is removing Manifest V2, which is used in this extension, I releasised that Firefox was not. So then I ported this to Firefox.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ A chrome extension that removes the obtrusive popup that prevents you from viewi
 
 When a popup appears simply click the extension icon to remove the popup and continue reading the article.
 
-Install the extension [here](https://chrome.google.com/webstore/detail/adblock-detector-bypass/acjlefdefjkldgcimnfkehgbnpjekedo)
+Install the .crx file from the assets to run. I have requested for this to be put up on AMO, nothing received yet.
 
 This is sure to work on most websites from my experience.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## AdBlock-Detector-Bypass
 
-A chrome extension that removes the obtrusive popup that prevents you from viewing webpage content when an adblocker is detected, and all in page popups in general.
+A firefox extension that removes the obtrusive popup that prevents you from viewing webpage content when an adblocker is detected, and all in page popups in general.
 
 When a popup appears simply click the extension icon to remove the popup and continue reading the article.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A firefox extension that removes the obtrusive popup that prevents you from view
 
 When a popup appears simply click the extension icon to remove the popup and continue reading the article.
 
-I have requested AMO for a .xpi file. Hang on. 
+I have requested AMO for a .xpi file. Hang on. If you want to use this extension, you have to use it as a temporary-add-on. Upload the background.js file to use it as a temporary add on.
 This is sure to work on most websites from my experience.
 
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ A firefox extension that removes the obtrusive popup that prevents you from view
 
 When a popup appears simply click the extension icon to remove the popup and continue reading the article.
 
-I have requested AMO for a .xpi file. Hang on. If you want to use this extension, you have to use it as a temporary-add-on. Upload the background.js file to use it as a temporary add on.
+
+To download this extension, go to the latest release and download the .xpi file. It is signed by Mozilla.
+
 This is sure to work on most websites from my experience.
 
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,6 @@
-## AdBlock-Detector-Bypass
+#ABDB
 
-A firefox extension that removes the obtrusive popup that prevents you from viewing webpage content when an adblocker is detected, and all in page popups in general.
-
-When a popup appears simply click the extension icon to remove the popup and continue reading the article.
+This is a Chrome extension I ported to firefox due to Chrome removing Manifest v2, something this extension needs. For the chrome extension (that will soon not work), click here:https://chrome.google.com/webstore/detail/adblock-detector-bypass/acjlefdefjkldgcimnfkehgbnpjekedo?hl=en-US
 
 
-To download this extension, go to the latest release and download the .xpi file. It is signed by Mozilla, or click [here](https://addons.mozilla.org/en-US/firefox/addon/adblock-detector-bypass/)
-
-This is sure to work on most websites from my experience.
-
-
-I made this because the original extension was very cool and I like to use it. As soon as I heard that Chrome is removing Manifest V2, which is used in this extension, I releasised that Firefox was not. So then I ported this to Firefox.
+For the firefox extension, click here (or look in the assets of the release): https://addons.mozilla.org/en-US/firefox/addon/adblock-detector-bypass/

--- a/README.md
+++ b/README.md
@@ -1,20 +1,9 @@
 ## AdBlock-Detector-Bypass
 
-A chrome extension that removes the obtrusive popup that prevents you from viewing webpage content when an adblocker is detected.
+A chrome extension that removes the obtrusive popup that prevents you from viewing webpage content when an adblocker is detected, and all in page popups in general.
 
-When an AdBlock Detector popup appears simply click the extension icon to remove the popup and continue reading the article.
+When a popup appears simply click the extension icon to remove the popup and continue reading the article.
 
 Install the extension [here](https://chrome.google.com/webstore/detail/adblock-detector-bypass/acjlefdefjkldgcimnfkehgbnpjekedo)
 
-### Verified to work on:
-- Forbes
-- USA Today
-- Business Insider
-- CNBC
-- Toronto Sun
-- NY Times
-- EuroGamer
-- USGamer
-- GamesRadar
-- Bloomberg
-- Toronto Star
+This is sure to work on most websites from my experience.

--- a/changeDom.js
+++ b/changeDom.js
@@ -4,6 +4,7 @@ xhr.onload = function() {
 	document.documentElement.innerHTML = this.responseXML.documentElement.outerHTML;
 	document.documentElement.style.overflow = "auto";
 	document.documentElement.style.position = "static";
+	document.documentElement.style.position = "auto";
 }
 
 xhr.open('GET', window.location.href);

--- a/changeDom.js
+++ b/changeDom.js
@@ -4,7 +4,7 @@ xhr.onload = function() {
 	document.documentElement.innerHTML = this.responseXML.documentElement.outerHTML;
 	document.documentElement.style.overflow = "auto";
 	document.documentElement.style.position = "static";
-	document.documentElement.style.position = "auto";
+	
 }
 
 xhr.open('GET', window.location.href);


### PR DESCRIPTION
Manifest v2 will be deleted from chrome this year, so I ported this to firefox. Link for chrome still is there. Link to the firefox extension also there.